### PR TITLE
check target不能用解析后的ip

### DIFF
--- a/cron/fetcher.go
+++ b/cron/fetcher.go
@@ -87,9 +87,9 @@ func newDetectedItem(s *model.Strategy, ip string, idc string) g.DetectedItem {
 
 	schema, domain, port, path := utils.ParseUrl(s.Url)
 	if port == "" {
-		detectedItem.Target = schema + "//" + ip + path
+		detectedItem.Target = schema + "//" + domain + path
 	} else {
-		detectedItem.Target = schema + "//" + ip + ":" + port + path
+		detectedItem.Target = schema + "//" + domain + ":" + port + path
 	}
 
 	detectedItem.Domain = domain


### PR DESCRIPTION
check target不能用解析后的ip，应当是域名。
Fixes #10 